### PR TITLE
Fix long description (and gemspec tweak)

### DIFF
--- a/lib/rollout/ui/views/features/index.slim
+++ b/lib/rollout/ui/views/features/index.slim
@@ -24,7 +24,7 @@ h2.font-semibold.text-xl.text-gray-500.pt-12.flex.items-center
       - @features.each do |feature_name|
         - feature = @rollout.get(feature_name)
         tr.border-b.border-gray-200
-          td.py-2.whitespace-no-wrap
+          td.py-2
             a.text-blue-600(href=feature_path(feature.name) class='hover:text-blue-700 hover:underline')
               = feature_name
             div.text-gray-500.text-xs = feature.data['description']

--- a/rollout-ui.gemspec
+++ b/rollout-ui.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rollout', '~> 2.5'
   spec.add_dependency 'sinatra', '~> 2.0'
-  spec.add_dependency 'sinatra-contrib', '~> 2.1'
-  spec.add_dependency 'slim', '~> 4.0'
+  spec.add_dependency 'sinatra-contrib', '~> 2.0'
+  spec.add_dependency 'slim', '~> 3.0.6'
 
   spec.add_development_dependency 'bundler', '>= 1.17'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
- fix long description issue (https://github.com/fetlife/rollout-ui/pull/6)
- tweak gemspec of last (unreleased) `0.2.0` version to be compatible with our gemfile

```
Bundler could not find compatible versions for gem "rack-protection":
  In snapshot (Gemfile.lock):
    rack-protection (= 2.0.5)

  In Gemfile:
    sendgrid-ruby (= 5.2.0) was resolved to 5.2.0, which depends on
      sinatra (>= 1.4.7, < 3) was resolved to 2.0.5, which depends on
        rack-protection (= 2.0.5)

    rollout-ui was resolved to 0.3.0, which depends on
      sinatra-contrib (~> 2.1) was resolved to 2.1.0, which depends on
        rack-protection (= 2.1.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

```
Bundler could not find compatible versions for gem "slim":
  In snapshot (Gemfile.lock):
    slim (= 3.0.6)

  In Gemfile:
    slim (= 3.0.6)

    rollout-ui was resolved to 0.3.0, which depends on
      slim (~> 4.0)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```
